### PR TITLE
Morph: set-output issue

### DIFF
--- a/.github/workflows/morph.yml
+++ b/.github/workflows/morph.yml
@@ -1,0 +1,22 @@
+# Example workflow
+
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set output values
+        run: |
+          echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_ENV
+          echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_ENV
+      - name: Use environment variables
+        run: |
+          echo "Version Code = $VERSION_CODE"
+          echo "Version Name = $VERSION_NAME"


### PR DESCRIPTION
This PR contains the following modifications:

- AI Prompt: "set-output workflow action is deprecated and should not be used. Instead environment variables should be used. 
Examples: 
<example_before>
run: echo "::set-output name=VERSION_NAME::${{ env.VERSION_NAME }}" && echo "::set-output name=VERSION_CODE::${{ env.VERSION_CODE }}" 
</example_before>

<example_fixed>
 run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_ENV && echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_ENV
</example_fixed>" (Single file: Yes)

Generated by Morph.