### PR TITLE
Morph: set-output issue 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: php -v
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v4.2.0
         with:


### PR DESCRIPTION
This PR contains the following modifications:

- AI Prompt: "set-output workflow action is deprecated and should not be used. Instead environment variables should be used. Do not introduce any new files!

Examples: ```<example_before> run: echo "::set-output name=VERSION_NAME::${{ env.VERSION_NAME }}" && echo "::set-output name=VERSION_CODE::${{ env.VERSION_CODE }}" </example_before> <example_fixed> run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_ENV && echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_ENV </example_fixed>```

" (Single file: Yes)

Generated by Morph.